### PR TITLE
Preventing a player with no wins causing scores to become NaN

### DIFF
--- a/score_calculation.py
+++ b/score_calculation.py
@@ -1,20 +1,24 @@
 import numpy as np
 
+
 def initialize_matrix(n):
     """Initialize an n x n matrix with zeros."""
     return np.zeros((n, n))
+
 
 def update_matrix(matrix, winner, loser, win_ratio=1, lose_ratio=0):
     """Update the matrix for a match result."""
     matrix[winner][loser] += win_ratio
     matrix[loser][winner] += lose_ratio
 
+
 def normalize_vector(v):
     """Normalize a vector."""
     norm = np.linalg.norm(v)
     if norm == 0:
-       return v
+        return v
     return v / norm
+
 
 def power_iteration(matrix, iterations=100, damping_factor=0.85):
     """Compute the dominant eigenvector using the power iteration method."""
@@ -27,22 +31,24 @@ def power_iteration(matrix, iterations=100, damping_factor=0.85):
         # Apply the damping factor
         b_k1 = (damping_factor * np.dot(matrix, b_k)) + ((1 - damping_factor) / n)
         b_k1 = normalize_vector(b_k1)
-        
+
         # Check convergence (optional)
         if np.allclose(b_k, b_k1):
             return b_k1
-        
+
         b_k = b_k1
-    
+
     return b_k
+
 
 def transform_win_loss_ratio(A):
     """Turns number of wins and losses into percentage."""
     A = np.array(A)
     A_transpose = A.T
-    transformed_A = np.divide(A, A + A_transpose, out=np.zeros_like(A), where=(A+A_transpose)!=0)
+    transformed_A = np.divide(A, A + A_transpose, out=np.zeros_like(A), where=(A + A_transpose) != 0)
     np.fill_diagonal(transformed_A, np.diag(A))
     return transformed_A
+
 
 def calculate_scores(data, num_players, offset=0.01):
     matrix = initialize_matrix(num_players)
@@ -55,7 +61,9 @@ def calculate_scores(data, num_players, offset=0.01):
 
     # Normalise columns
     norms = np.linalg.norm(matrix, axis=0)
-    matrix = matrix / norms
+    np.divide(
+        matrix, norms, out=matrix, where=(norms != 0)
+    )
 
     matrix += offset
     rankings = power_iteration(matrix)


### PR DESCRIPTION
Fixed error where a player with no wins causes the normalised score matrix to have `NaN`s